### PR TITLE
Build the container fresh if the action is not invoked from a tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ runs:
     # Detect this by stripping off 'refs/tags/v' from the ref used for the action and comparing it to the ref.
     # Otherwise, build the container fresh.
     - id: get-container
+      shell: bash
       env:
         ACTION_REF: ${{ github.action_ref }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -8,22 +8,37 @@ inputs:
     description: 'The name of the rendered PDF file'
     required: true
 runs:
-  using: 'docker'
-  image: docker://ghcr.io/trustedcomputinggroup/markdown:r0.0.4
-  args:
-    - '--template=eisvogel.latex'
-    - '--resource-path=/resources'
-    - '--data-dir=/resources'
-    - '--toc'
-    - '--variable=block-headings'
-    - '--metadata=titlepage:true'
-    - '--metadata=titlepage-background:/resources/img/cover.png'
-    - '--metadata=logo:/resources/img/tcg.png'
-    - '--metadata=titlepage-rule-height:0'
-    - '--metadata=colorlinks:true'
-    - '--metadata=toc-own-page:true'
-    - '--metadata=contact:admin@trustedcomputinggroup.org'
-    - '--from=markdown'
-    - '--to=pdf'
-    - '${{ inputs.input-md }}'
-    - '--output=${{ inputs.output-pdf }}'
+  using: 'composite'
+  steps:
+    # If the action is being used from a tag, use the corresponding prebuilt container.
+    # Detect this by stripping off 'refs/tags/v' from the ref used for the action and comparing it to the ref.
+    # Otherwise, build the container fresh.
+    - id: get-container
+      env:
+        ACTION_REF: ${{ github.action_ref }}
+      run: |
+        TAG=${ACTION_REF#refs/tags/v}
+        if [[ "$TAG" == "$ACTION_REF" ]]; then
+        echo ::set-output name=container::Dockerfile
+        else
+        echo ::set-output name=container::docker://ghcr.io/trustedcomputinggroup/markdown:r$TAG
+        fi
+    - uses: ${{ steps.get-container.outputs.container }}
+      with:
+        args:
+          - '--template=eisvogel.latex'
+          - '--resource-path=/resources'
+          - '--data-dir=/resources'
+          - '--toc'
+          - '--variable=block-headings'
+          - '--metadata=titlepage:true'
+          - '--metadata=titlepage-background:/resources/img/cover.png'
+          - '--metadata=logo:/resources/img/tcg.png'
+          - '--metadata=titlepage-rule-height:0'
+          - '--metadata=colorlinks:true'
+          - '--metadata=toc-own-page:true'
+          - '--metadata=contact:admin@trustedcomputinggroup.org'
+          - '--from=markdown'
+          - '--to=pdf'
+          - '${{ inputs.input-md }}'
+          - '--output=${{ inputs.output-pdf }}'


### PR DESCRIPTION
Experimental: Attempt to detect whether the action is being invoked from a tag or not.
If the action is invoked by tag, use the prebuilt container to avoid wastefully building the same thing over and over again.
Otherwise (e.g. the action is being invoked from head, maybe as part of a PR presubmit on this repo), build the container on demand.