### PR TITLE
Build the container fresh every time

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: docker://ghcr.io/trustedcomputinggroup/markdown:r0.0.4
+  image: 'Dockerfile'
   args:
     - '--template=eisvogel.latex'
     - '--resource-path=/resources'


### PR DESCRIPTION
We're building a container now, which is nice for local use. In theory, this action should use the pre-built container instead of making it on the fly every time (which wastes around 25 seconds per run).

However, we really need for PRs to this action to build a fresh Docker container and run it, so we can test it.

I attempted to make a smart solution in https://github.com/TrustedComputingGroup/markdown/pull/2 that would detect whether the action was being referenced by tag or not, and pass a variable to the composite action 'uses' Docker syntax, but it didn't work.