### PR TITLE
Remove deprecated save-output command

### DIFF
--- a/.github/workflows/render-samples.yml
+++ b/.github/workflows/render-samples.yml
@@ -34,6 +34,14 @@ jobs:
           output-docx: sample2.docx
           output-tex: sample2.tex
 
+      - name: Run the action on sample3
+        uses: ./
+        with:
+          input-md: sample3.md
+          output-pdf: sample3.pdf
+          output-docx: sample3.docx
+          output-tex: sample3.tex
+
       - name: Upload Artifact
         uses: actions/upload-artifact@master
         with:

--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,9 @@ runs:
     - run: |
         DATE=$(grep date: ${{ inputs.input-md }} | head -n 1 | cut -d ' ' -f 2)
         YEAR=$(date --date=$DATE +%Y)
-        echo "::set-output name=year::$YEAR"
+        echo "year=$YEAR" >> $GITHUB_STATE
         DATE_ENGLISH=$(date --date=$DATE "+%B %-d, %Y")
-        echo "::set-output name=date-english::$DATE_ENGLISH"
+        echo "date-english=$DATE_ENGLISH" >> $GITHUB_STATE
       shell: bash
       id: date
     - run: >

--- a/sample3.md
+++ b/sample3.md
@@ -146,4 +146,19 @@ Table: Fantastic Table
 | ------------ | ------------ | ------------ |
 | AAAAAAAA     | BBBBBBBB     | CCCCCCCC     |
 
+## Temperatures
+
+This section contains a Grid Table.
+
++---------------------+-----------------------+
+| Location            | Temperature 1961-1990 |
+|                     | in degree Celsius     |
+|                     +-------+-------+-------+
+|                     | min   | mean  | max   |
++=====================+=======+=======+=======+
+| Antarctica          | -89.2 | N/A   | 19.8  |
++---------------------+-------+-------+-------+
+| Earth               | -89.2 | 14    | 56.7  |
++---------------------+-------+-------+-------+
+
 # References


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This change also adds a Grid Table to sample3 and includes it in the render-samples action.