### PR TITLE
refactor action to use build.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,139 +18,31 @@ runs:
     # workaround to https://github.com/actions/runner/issues/2033
     - run: chown -R $(id -u):$(id -g) $PWD
       shell: sh
-    # There are some configuration dependencies required for Mermaid.
-    # They have to be in the current directory.
-    - run: |
-        cat << EOF > ./.puppeteer.json
-        {
-            "executablePath": "/usr/bin/chromium-browser",
-            "args": [
-                "--no-sandbox",
-                "--disable-setuid-sandbox"
-            ]
-        }
-        EOF
-      shell: sh
-    # GitHub Mermaid doesn't recognize the full ```{.mermaid ...} attributes-form
-    # Pandoc doesn't recognized mixed ```mermaid {...} form
-    # Hack: use sed to transform the former to the latter so everyone is happy
     - run: >
-        sed -i
-        's/```mermaid *{/```{.mermaid /g'
+        /usr/bin/build.sh
+        --puppeteer
+        --pdf=${{ inputs.output-pdf }}
         ${{ inputs.input-md }}
-      shell: sh
-    # \newpage is rendered as the string "\newpage" in GitHub markdown.
-    # Transform horizontal rules into \newpages.
-    # Exception: the YAML front matter of the document, so undo the instance on the first line.
-    - run: >
-        sed -i
-        's/^---$/\\newpage/g;1s/\\newpage/---/g'
-        ${{ inputs.input-md }}
-      shell: sh
-    # Transform sections before the table of contents into addsec, which does not number them.
-    # While we're doing this, transform the case to all-caps.
-    - run: >
-        sed -i
-        '0,/\\tableofcontents/s/^# \(.*\)/\\addsec\{\U\1\}/g'
-        ${{ inputs.input-md }}
-      shell: sh
-    # Grab the date from the front matter and generate the full date and year.
-    - run: |
-        DATE=$(grep date: ${{ inputs.input-md }} | head -n 1 | cut -d ' ' -f 2)
-        YEAR=$(date --date=$DATE +%Y)
-        echo "year=$YEAR" >> $GITHUB_STATE
-        DATE_ENGLISH=$(date --date=$DATE "+%B %-d, %Y")
-        echo "date-english=$DATE_ENGLISH" >> $GITHUB_STATE
-      shell: bash
-      id: date
-    - run: >
-        pandoc
-        --trace
-        --pdf-engine=lualatex
-        --embed-resources
-        --standalone
-        --template=eisvogel.latex
-        --filter=mermaid-filter
-        --filter=pandoc-crossref
-        --lua-filter=table-rules.lua
-        --lua-filter=parse-html.lua
-        --resource-path=.:/resources
-        --data-dir=/resources
-        --top-level-division=section
-        --variable=block-headings
-        --variable=numbersections
-        --metadata=tables-vrules:true
-        --metadata=tables-hrules:true
-        --metadata=crossrefYaml:/resources/filters/pandoc-crossref.yaml
-        --metadata=date-english:"${{ steps.date.outputs.date-english }}"
-        --metadata=year:"${{ steps.date.outputs.year }}"
-        --metadata=titlepage:true
-        --metadata=titlepage-background:/resources/img/cover.png
-        --metadata=logo:/resources/img/tcg.png
-        --metadata=titlepage-rule-height:0
-        --metadata=colorlinks:true
-        --metadata=contact:admin@trustedcomputinggroup.org
-        --from=markdown+implicit_figures+grid_tables+table_captions-markdown_in_html_blocks
-        --to=pdf
-        ${{ inputs.input-md }}
-        --output=${{ inputs.output-pdf }}
       shell: sh
       env:
         MERMAID_FILTER_THEME: "forest"
         MERMAID_FILTER_FORMAT: "pdf"
     - run: >
-        pandoc
-        --trace
-        --pdf-engine=lualatex
-        --embed-resources
-        --standalone
-        --template=eisvogel.latex
-        --filter=mermaid-filter
-        --filter=pandoc-crossref
-        --lua-filter=table-rules.lua
-        --lua-filter=parse-html.lua
-        --resource-path=.:/resources
-        --data-dir=/resources
-        --top-level-division=section
-        --variable=block-headings
-        --variable=numbersections
-        --metadata=tables-vrules:true
-        --metadata=tables-hrules:true
-        --metadata=crossrefYaml:/resources/filters/pandoc-crossref.yaml
-        --metadata=date-english:"${{ steps.date.outputs.date-english }}"
-        --metadata=year:"${{ steps.date.outputs.year }}"
-        --metadata=titlepage:true
-        --metadata=titlepage-background:/resources/img/cover.png
-        --metadata=logo:/resources/img/tcg.png
-        --metadata=titlepage-rule-height:0
-        --metadata=colorlinks:true
-        --metadata=contact:admin@trustedcomputinggroup.org
-        --from=markdown+implicit_figures+grid_tables+table_captions-markdown_in_html_blocks
-        --to=latex
+        /usr/bin/build.sh
+        --puppeteer
+        --latex=${{ inputs.output-tex }}
         ${{ inputs.input-md }}
-        --output=${{ inputs.output-tex }}
       shell: sh
       if: ${{ inputs.output-tex }} 
       env:
         MERMAID_FILTER_THEME: "forest"
         MERMAID_FILTER_FORMAT: "pdf"
     - run: >
-        pandoc
-        --trace
-        --pdf-engine=lualatex
-        --embed-resources
-        --standalone
-        --filter=/resources/filters/info.py
-        --filter=mermaid-filter
-        --filter=pandoc-crossref
-        --lua-filter=parse-html.lua
-        --resource-path=.:/resources
-        --data-dir=/resources
-        --from=markdown+implicit_figures+grid_tables+table_captions-markdown_in_html_blocks
-        --reference-doc=/resources/templates/tcg_template.docx
-        --to=docx
+        /usr/bin/build.sh
+        --puppeteer
+        --pdf=${{ inputs.output-pdf }}
+        --docx=${{ inputs.output-docx }}
         ${{ inputs.input-md }}
-        --output=${{ inputs.output-docx }}
       shell: sh
       if: ${{ inputs.output-docx }} 
       env:


### PR DESCRIPTION
This change to the action allows the pandoc container's build script to control all the fixups, workarounds, and options to pandoc.